### PR TITLE
Remove References to Bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.3
 
-RUN apk add --no-cache curl bash jq
+RUN apk add --no-cache curl jq
 
 COPY check /opt/resource/check
 COPY in    /opt/resource/in

--- a/check
+++ b/check
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "[]"

--- a/in
+++ b/in
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 echo '{"version":{"ref":"none"}}'


### PR DESCRIPTION
We don't need to pull bash into the container if we don't run any bash scripts. The two scripts (check, in) that were using it really don't need bash and can instead use sh instead.